### PR TITLE
Fix post-auth redirect

### DIFF
--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -39,11 +39,11 @@ export default function LoginPage() {
         name: email.split("@")[0],
         picture: null,
       }
-      localStorage.setItem("user", JSON.stringify(user))
+      localStorage.setItem("demoUser", JSON.stringify(user))
 
       setMessage("Login successful! Redirecting...")
       setTimeout(() => {
-        router.push("/")
+        router.push("/chat")
       }, 1500)
     } catch (err) {
       setError("An unexpected error occurred. Please try again.")

--- a/app/sign-in/[[...sign-in]]/page.tsx
+++ b/app/sign-in/[[...sign-in]]/page.tsx
@@ -51,13 +51,13 @@ export default function SignInPage() {
           JSON.stringify({ name: 'Demo User', email })
         )
       }
-      router.push("/")
+      router.push("/chat")
       return
     }
 
     try {
       await signInWithEmailAndPassword(auth, email, password)
-      router.push("/")
+      router.push("/chat")
     } catch (error: any) {
       console.error("Error signing in:", error)
       setError(error.message || "Failed to sign in")
@@ -76,14 +76,14 @@ export default function SignInPage() {
           JSON.stringify({ name: 'Demo User', email: 'demo@example.com' })
         )
       }
-      router.push("/")
+      router.push("/chat")
       return
     }
 
     try {
       const provider = new GoogleAuthProvider()
       await signInWithPopup(auth, provider)
-      router.push("/")
+      router.push("/chat")
     } catch (error: any) {
       console.error("Error signing in with Google:", error)
       setError(error.message || "Failed to sign in with Google")

--- a/app/sign-up/[[...sign-up]]/page.tsx
+++ b/app/sign-up/[[...sign-up]]/page.tsx
@@ -44,7 +44,7 @@ export default function SignUpPage() {
           JSON.stringify({ name, email })
         )
       }
-      router.push("/")
+      router.push("/chat")
       return
     }
 
@@ -66,7 +66,7 @@ export default function SignUpPage() {
         role: "user"
       })
 
-      router.push("/")
+      router.push("/chat")
     } catch (error: any) {
       console.error("Error signing up:", error)
       setError(error.message || "Failed to sign up")
@@ -85,7 +85,7 @@ export default function SignUpPage() {
           JSON.stringify({ name: 'Demo User', email: 'demo@example.com' })
         )
       }
-      router.push("/")
+      router.push("/chat")
       return
     }
 
@@ -102,7 +102,7 @@ export default function SignUpPage() {
         role: "user"
       }, { merge: true })
 
-      router.push("/")
+      router.push("/chat")
     } catch (error: any) {
       console.error("Error signing up with Google:", error)
       setError(error.message || "Failed to sign up with Google")


### PR DESCRIPTION
## Summary
- redirect login, sign-in and sign-up flows to `/chat`
- store demo auth data consistently

## Testing
- `npx next lint`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_68548d7d3928832684a75b878d2adbcd
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Redirects login, sign-in, and sign-up flows to `/chat` and stores demo user data consistently.
> 
>   - **Behavior**:
>     - Redirects login, sign-in, and sign-up flows to `/chat` in `page.tsx` files for `login`, `sign-in`, and `sign-up`.
>     - Stores demo user data in `localStorage` under `demoUser` key in `login/page.tsx`, `sign-in/[[...sign-in]]/page.tsx`, and `sign-up/[[...sign-up]]/page.tsx`.
>   - **Testing**:
>     - Run `npx next lint` for linting.
>     - Run `npm run type-check` for type checking.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ogprotege%2Fex314-combo&utm_source=github&utm_medium=referral)<sup> for 5f12ae493451203fc648c81e847ce2c14b778d14. You can [customize](https://app.ellipsis.dev/ogprotege/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->