### PR TITLE
Fix unused imports in Cloud Functions

### DIFF
--- a/ex314-codebase/src/index.ts
+++ b/ex314-codebase/src/index.ts
@@ -13,7 +13,7 @@ import * as logger from "firebase-functions/logger";
 // Start writing functions
 // https://firebase.google.com/docs/functions/typescript
 
-// export const helloWorld = onRequest((request, response) => {
-//   logger.info("Hello logs!", {structuredData: true});
-//   response.send("Hello from Firebase!");
-// });
+export const helloWorld = onRequest((request, response) => {
+  logger.info("Hello logs!", {structuredData: true});
+  response.send("Hello from Firebase!");
+});

--- a/functions/src/genkit-sample.ts
+++ b/functions/src/genkit-sample.ts
@@ -10,7 +10,7 @@ import {gemini20Flash} from "@genkit-ai/vertexai";
 // function from a Genkit action. It automatically implements streaming if your flow does.
 // The https library also has other utility methods such as hasClaim, which verifies that
 // a caller's token has a specific claim (optionally matching a specific value)
-import {onCallGenkit, hasClaim} from "firebase-functions/https";
+import {onCallGenkit} from "firebase-functions/https";
 
 // Genkit models generally depend on an API key. APIs should be stored in Cloud Secret Manager so that
 // access to these sensitive values can be controlled. defineSecret does this for you automatically.

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -13,7 +13,7 @@ import * as logger from "firebase-functions/logger";
 // Start writing functions
 // https://firebase.google.com/docs/functions/typescript
 
-// export const helloWorld = onRequest((request, response) => {
-//   logger.info("Hello logs!", {structuredData: true});
-//   response.send("Hello from Firebase!");
-// });
+export const helloWorld = onRequest((request, response) => {
+  logger.info("Hello logs!", {structuredData: true});
+  response.send("Hello from Firebase!");
+});


### PR DESCRIPTION
## Summary
- export `helloWorld` Cloud Function in both packages
- remove unused `hasClaim` import in `genkit-sample`

## Testing
- `npm run build` in `functions`
- `npm run build` in `ex314-codebase`


------
https://chatgpt.com/codex/tasks/task_e_68584533aa008326b0fbc6074d34cbba
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes unused imports and exports `helloWorld` function in Cloud Functions.
> 
>   - **Behavior**:
>     - Export `helloWorld` function in `ex314-codebase/src/index.ts` and `functions/src/index.ts`.
>     - Remove unused `hasClaim` import from `functions/src/genkit-sample.ts`.
>   - **Testing**:
>     - Run `npm run build` in `functions` and `ex314-codebase`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ogprotege%2Fex314-combo&utm_source=github&utm_medium=referral)<sup> for 3d40700ee941e2341b38deccd093fe8f5ad6ae12. You can [customize](https://app.ellipsis.dev/ogprotege/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->